### PR TITLE
Solved {t1 t2} -> p problem

### DIFF
--- a/example/echo/main.go
+++ b/example/echo/main.go
@@ -22,7 +22,7 @@ func main() {
 	n.P("res",
 		cpn.WithContext(ctx),
 		cpn.WithPlace(http.NewHttpResponse()),
-		cpn.IsTermination(),
+		cpn.IsFinal(),
 	)
 
 	n.PT("req", "echo").TP("echo", "res").Run()

--- a/example/ptnpn/main.go
+++ b/example/ptnpn/main.go
@@ -15,9 +15,9 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	n := cpn.NewPN()
-	n.P("pin", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()))
+	n.P("pin", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
 	n.Tn(places, "t_", cpn.WithFunction(transition.First))
-	n.Pn(places, "p_", cpn.WithContext(ctx), cpn.WithPlaceBuilder(place.NewBlock), cpn.IsTermination())
+	n.Pn(places, "p_", cpn.WithContext(ctx), cpn.WithPlaceBuilder(place.NewBlock), cpn.IsFinal())
 	n.PTn(places, "pin", "t_").TnPn(places, "t_", "p_")
 
 	go func() {

--- a/example/ptp/main.go
+++ b/example/ptp/main.go
@@ -12,9 +12,9 @@ import (
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	n := cpn.NewPN()
-	n.P("pin", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()))
+	n.P("pin", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
 	n.T("t1", cpn.WithFunction(transition.First))
-	n.P("pout", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()), cpn.IsTermination())
+	n.P("pout", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()), cpn.IsFinal())
 
 	n.PT("pin", "t1").TP("t1", "pout").Run()
 

--- a/o.go
+++ b/o.go
@@ -48,14 +48,24 @@ func (o placeBuilderOpt) Apply(p *P) {
 	p.place = o.builder(o.opts...)
 }
 
-func IsTermination() POpt {
-	return terminationOpt{}
+func IsFinal() POpt {
+	return finalOpt{}
 }
 
-type terminationOpt struct{}
+type finalOpt struct{}
 
-func (o terminationOpt) Apply(p *P) {
+func (o finalOpt) Apply(p *P) {
 	p.t = true
+}
+
+func IsInitial() POpt {
+	return initialOpt{}
+}
+
+type initialOpt struct{}
+
+func (o initialOpt) Apply(p *P) {
+	p.i = true
 }
 
 type TOpt interface {

--- a/test/pn_bench_test.go
+++ b/test/pn_bench_test.go
@@ -12,133 +12,127 @@ import (
 
 func BenchmarkBlockPTP(b *testing.B) {
 	n := cpn.NewPN()
-	n.P("pin", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
+	n.P("pin", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
 	n.T("t1", cpn.WithFunction(transition.First))
-	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
-
-	n.PT("pin", "t1").TP("t1", "pout").Run()
+	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()), cpn.IsFinal())
 
 	mm := make([]*cpn.M, b.N)
 	for i := 0; i < b.N; i += 1 {
 		mm[i] = cpn.NewM(i)
 	}
 
+	n.PT("pin", "t1").TP("t1", "pout").Run()
 	b.ResetTimer()
 	for i := 0; i < b.N; i += 1 {
 		n.P("pin").In() <- mm[i]
-		n.P("pout").Read()
+		<-n.P("pout").Out()
 	}
 }
 
 func BenchmarkBlockPTPTP(b *testing.B) {
 	n := cpn.NewPN()
-	n.P("pin", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
+	n.P("pin", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
 	n.P("p1", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
-	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
+	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()), cpn.IsFinal())
 	n.T("t1", cpn.WithFunction(transition.First))
 	n.T("t2", cpn.WithFunction(transition.First))
-
-	n.PT("pin", "t1").TP("t1", "p1").PT("p1", "t2").TP("t2", "pout").Run()
 
 	mm := make([]*cpn.M, b.N)
 	for i := 0; i < b.N; i += 1 {
 		mm[i] = cpn.NewM(i)
 	}
 
+	n.PT("pin", "t1").TP("t1", "p1").PT("p1", "t2").TP("t2", "pout").Run()
 	b.ResetTimer()
 	for i := 0; i < b.N; i += 1 {
 		n.P("pin").In() <- mm[i]
-		n.P("pout").Read()
+		<-n.P("pout").Out()
 	}
 }
 
 func BenchmarkBlockPTPTPTP(b *testing.B) {
 	n := cpn.NewPN()
-	n.P("pin", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
+	n.P("pin", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
 	n.P("p1", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
 	n.P("p2", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
-	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
+	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()), cpn.IsFinal())
 	n.T("t1", cpn.WithFunction(transition.First))
 	n.T("t2", cpn.WithFunction(transition.First))
 	n.T("t3", cpn.WithFunction(transition.First))
-
-	n.PT("pin", "t1").TP("t1", "p1").PT("p1", "t2").TP("t2", "p2").PT("p2", "t3").
-		TP("t3", "pout").Run()
 
 	mm := make([]*cpn.M, b.N)
 	for i := 0; i < b.N; i += 1 {
 		mm[i] = cpn.NewM(i)
 	}
 
+	n.PT("pin", "t1").TP("t1", "p1").PT("p1", "t2").TP("t2", "p2").PT("p2", "t3").
+		TP("t3", "pout").Run()
 	b.ResetTimer()
 	for i := 0; i < b.N; i += 1 {
 		n.P("pin").In() <- mm[i]
-		n.P("pout").Read()
+		<-n.P("pout").Out()
 	}
 }
 
 func BenchmarkQueuePTP(b *testing.B) {
 	n := cpn.NewPN()
-	n.P("pin", cpn.WithContext(context.Background()), cpn.WithPlace(memory.NewQueue(100)))
+	n.P("pin", cpn.WithContext(context.Background()), cpn.WithPlace(memory.NewQueue(100)), cpn.IsInitial())
 	n.T("t1", cpn.WithFunction(transition.First))
-	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(memory.NewQueue(100)))
-
-	n.PT("pin", "t1").TP("t1", "pout").Run()
+	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(memory.NewQueue(100)), cpn.IsFinal())
 
 	mm := make([]*cpn.M, b.N)
 	for i := 0; i < b.N; i += 1 {
 		mm[i] = cpn.NewM(i)
 	}
 
+	n.PT("pin", "t1").TP("t1", "pout").Run()
 	b.ResetTimer()
 	for i := 0; i < b.N; i += 1 {
 		n.P("pin").In() <- mm[i]
-		n.P("pout").Read()
+		<-n.P("pout").Out()
 	}
 }
 
 func BenchmarkPPTP(b *testing.B) {
 	n := cpn.NewPN()
-	n.P("p1", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
-	n.P("p2", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
+	n.P("p1", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
+	n.P("p2", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
 	n.T("t1", cpn.WithFunction(transition.First))
-	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
-
-	n.PT("p1", "t1").PT("p2", "t1").TP("t1", "pout").Run()
+	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()), cpn.IsFinal())
 
 	mm := make([]*cpn.M, b.N)
 	for i := 0; i < b.N; i += 1 {
 		mm[i] = cpn.NewM(i)
 	}
 
+	n.PT("p1", "t1").PT("p2", "t1").TP("t1", "pout").Run()
 	b.ResetTimer()
 	for i := 0; i < b.N; i += 1 {
 		n.P("p1").In() <- mm[i]
 		n.P("p2").In() <- mm[i]
-		n.P("pout").Read()
+		<-n.P("pout").Out()
 	}
 }
 
 func BenchmarkPPTTP(b *testing.B) {
 	n := cpn.NewPN()
-	n.P("p1", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
-	n.P("p2", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
+	n.P("p1", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
+	n.P("p2", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
 	n.T("t1", cpn.WithFunction(transition.First))
 	n.T("t2", cpn.WithFunction(transition.First))
-	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
-
-	n.PT("p1", "t1").PT("p2", "t1").PT("p1", "t2").PT("p2", "t2").
-		TP("t1", "pout").TP("t2", "pout").Run()
+	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()), cpn.IsFinal())
 
 	mm := make([]*cpn.M, b.N)
 	for i := 0; i < b.N; i += 1 {
 		mm[i] = cpn.NewM(i)
 	}
 
+	n.PT("p1", "t1").PT("p2", "t1").PT("p1", "t2").PT("p2", "t2").
+		TP("t1", "pout").TP("t2", "pout").Run()
 	b.ResetTimer()
 	for i := 0; i < b.N; i += 1 {
 		n.P("p1").In() <- mm[i]
 		n.P("p2").In() <- mm[i]
-		n.P("pout").Read()
+		<-n.P("pout").Out()
 	}
 }

--- a/test/pn_test.go
+++ b/test/pn_test.go
@@ -1,15 +1,14 @@
 package test
 
 import (
-	"bytes"
-
-	"github.com/alxmsl/cpn/place"
 	. "gopkg.in/check.v1"
 
+	"bytes"
 	"context"
 	"testing"
 
 	"github.com/alxmsl/cpn"
+	"github.com/alxmsl/cpn/place"
 	"github.com/alxmsl/cpn/transition"
 )
 
@@ -22,75 +21,100 @@ type PNSuite struct{}
 var _ = Suite(&PNSuite{})
 
 func (s *PNSuite) TestPTP(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	n := cpn.NewPN()
-	n.P("pin", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
+	n.P("pin", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
 	n.T("t1", cpn.WithFunction(transition.First))
-	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
+	n.P("pout", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()), cpn.IsFinal())
 
 	n.PT("pin", "t1").TP("t1", "pout").Run()
 
-	for i := 0; i < 1000; i += 1 {
-		n.P("pin").In() <- cpn.NewM(i)
-		m, ok := n.P("pout").Read()
-		c.Assert(ok, Equals, true)
+	go func() {
+		for i := 0; i < 1000; i += 1 {
+			n.P("pin").In() <- cpn.NewM(i)
+		}
+		cancel()
+	}()
+
+	i := 0
+	for m := range n.P("pout").Out() {
 		c.Assert(m.Value().(int), Equals, i)
 		c.Assert(m.Path(), HasLen, 3)
 		c.Assert(m.Path()[0], Equals, "pin")
 		c.Assert(m.Path()[1], Equals, "t1")
 		c.Assert(m.Path()[2], Equals, "pout")
+		i += 1
 	}
 }
 
 func (s *PNSuite) TestPPTP(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	n := cpn.NewPN()
-	n.P("p1", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
-	n.P("p2", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
+	n.P("p1", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
+	n.P("p2", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
 	n.T("t1", cpn.WithFunction(transition.First))
-	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
+	n.P("pout", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()), cpn.IsFinal())
 
 	n.PT("p1", "t1").PT("p2", "t1").TP("t1", "pout").Run()
 
-	for i := 0; i < 1000; i += 1 {
-		n.P("p1").In() <- cpn.NewM(i)
-		n.P("p2").In() <- cpn.NewM(i)
-		m, ok := n.P("pout").Read()
-		c.Assert(ok, Equals, true)
+	go func() {
+		for i := 0; i < 1000; i += 1 {
+			n.P("p1").In() <- cpn.NewM(i)
+			n.P("p2").In() <- cpn.NewM(i)
+		}
+		cancel()
+	}()
+
+	i := 0
+	for m := range n.P("pout").Out() {
 		c.Assert(m.Value().(int), Equals, i)
 		c.Assert(m.Path(), HasLen, 3)
+		c.Assert(m.Path()[0] == "p1" || m.Path()[0] == "p2", Equals, true)
 		c.Assert(m.Path()[1], Equals, "t1")
 		c.Assert(m.Path()[2], Equals, "pout")
+		i += 1
 	}
 }
 
 func (s *PNSuite) TestPPTTP(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	n := cpn.NewPN()
-	n.P("p1", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
-	n.P("p2", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
+	n.P("p1", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
+	n.P("p2", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
 	n.T("t1", cpn.WithFunction(transition.First))
 	n.T("t2", cpn.WithFunction(transition.First))
-	n.P("pout", cpn.WithContext(context.Background()), cpn.WithPlace(place.NewBlock()))
+	n.P("pout", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()), cpn.IsFinal())
 
 	n.PT("p1", "t1").PT("p2", "t1").PT("p1", "t2").PT("p2", "t2").
 		TP("t1", "pout").TP("t2", "pout").Run()
 
-	for i := 0; i < 1000; i += 1 {
-		n.P("p1").In() <- cpn.NewM(i)
-		n.P("p2").In() <- cpn.NewM(i)
+	go func() {
+		for i := 0; i < 1000; i += 1 {
+			n.P("p1").In() <- cpn.NewM(i)
+			n.P("p2").In() <- cpn.NewM(i)
+		}
+		cancel()
+	}()
 
-		m, ok := n.P("pout").Read()
-		c.Assert(ok, Equals, true)
-		c.Assert(m.Value().(int), Equals, i)
+	for m := range n.P("pout").Out() {
+		c.Assert(m.Path(), HasLen, 3)
+		c.Assert(m.Path()[0] == "p1" || m.Path()[0] == "p2", Equals, true)
+		c.Assert(m.Path()[1] == "t1" || m.Path()[1] == "t2", Equals, true)
+		c.Assert(m.Path()[2], Equals, "pout")
 	}
 }
 
 func (s *PNSuite) TestPrintNet(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	n := cpn.NewPN()
-	n.P("pin", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()))
+	n.P("pin", cpn.WithContext(ctx), cpn.WithPlace(place.NewBlock()), cpn.IsInitial())
 	n.T("t1", cpn.WithFunction(transition.First))
 
 	w := bytes.NewBufferString("")
-	n.P("pout", cpn.WithContext(ctx), cpn.WithPlace(place.NewPrint(place.WriterOption(w))), cpn.IsTermination())
+	n.P("pout", cpn.WithContext(ctx), cpn.WithPlace(place.NewPrint(place.WriterOption(w))), cpn.IsFinal())
 
 	n.PT("pin", "t1").TP("t1", "pout")
 


### PR DESCRIPTION
```shell
=== RUN   Test
panic: close of closed channel

goroutine 47 [running]:
github.com/alxmsl/cpn.(*T).run.func3(0x0, 0x12e4838, 0x4, 0x12c8380, 0xc0001025a0, 0x14c8f00)
	/Users/alxmsl/sources.go/src/github.com/alxmsl/cpn/t.go:100 +0x66
github.com/alxmsl/prmtvs/skm.(*SKM).Over(0xc0001993c0, 0x12efcd8)
	/Users/alxmsl/sources.go/pkg/mod/github.com/alxmsl/prmtvs@v1.0.0/skm/skm.go:123 +0x188
github.com/alxmsl/cpn.(*T).run(0xc0000847b0)
	/Users/alxmsl/sources.go/src/github.com/alxmsl/cpn/t.go:99 +0x556
created by github.com/alxmsl/cpn.(*PN).Run.func2
	/Users/alxmsl/sources.go/src/github.com/alxmsl/cpn/pn.go:90 +0x5e
FAIL	github.com/alxmsl/cpn/test	0.442s
?   	github.com/alxmsl/cpn/transition	[no test files]
FAIL
make: *** [test] Error 1
```