### PR TITLE
Added ability to store multiple values for marks from different places.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CPN CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    name: run tests
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        go-version: [1.16, 1.17, 1.18]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Install Golang
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Check formatting
+        run: |
+          if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
+            gofmt -s -l .
+            echo "Please format the source code by running: make fmt"
+            exit 1
+          fi
+      - name: Run tests
+        run: make test

--- a/p.go
+++ b/p.go
@@ -95,7 +95,7 @@ func (p *P) startRecv() {
 		go func() {
 			defer wg.Done()
 			for m := range v.(chan *M) {
-				m.PassP(p.Name())
+				m.passP(p)
 				p.place.In() <- m
 			}
 		}()
@@ -112,7 +112,8 @@ func (p *P) startRecv() {
 func (p *P) startSend() {
 	if p.t {
 		if !p.k {
-			for range p.place.Out() {
+			for m := range p.place.Out() {
+				m.passP(p)
 			}
 		}
 		return
@@ -126,7 +127,7 @@ func (p *P) startSend() {
 			}
 			atomic.AddInt64(&p.s, stateReady)
 
-			m.PassP(p.Name())
+			m.passP(p)
 			p.out <- m
 
 			atomic.AddInt64(&p.s, -stateReady)

--- a/place/pass.go
+++ b/place/pass.go
@@ -1,0 +1,60 @@
+package place
+
+import (
+	"context"
+
+	"github.com/alxmsl/cpn"
+)
+
+type (
+	PassFunc func(context.Context, *cpn.M)
+
+	pass struct {
+		chin  chan *cpn.M
+		chout chan *cpn.M
+
+		f PassFunc
+	}
+)
+
+// PassFuncOption returns a place option contains a PassFunc
+func PassFuncOption(f PassFunc) cpn.PlaceOption {
+	return passOption{f}
+}
+
+type passOption struct {
+	f PassFunc
+}
+
+func (o passOption) Apply(p cpn.Place) {
+	p.(*pass).f = o.f
+}
+
+// NewPass returns a Pass Place. The Pass Place gets one mark and passes it forward. It is allowed to modify a mark's
+// value using function PassFunc
+func NewPass(opts ...cpn.PlaceOption) cpn.Place {
+	r := &pass{
+		chin:  make(chan *cpn.M),
+		chout: make(chan *cpn.M),
+	}
+	for _, o := range opts {
+		o.Apply(r)
+	}
+	return r
+}
+
+func (p *pass) In() chan<- *cpn.M {
+	return p.chin
+}
+
+func (p *pass) Out() <-chan *cpn.M {
+	return p.chout
+}
+
+func (p *pass) Run() {
+	defer close(p.chout)
+	for m := range p.chin {
+		p.f(context.Background(), m)
+		p.chout <- m
+	}
+}

--- a/t.go
+++ b/t.go
@@ -86,7 +86,7 @@ func (t *T) run() {
 		}
 
 		m := t.fn(mm)
-		m.PassT(t.Name())
+		m.passT(t)
 
 		t.outs.Over(func(i int, n string, v interface{}) bool {
 			in, _ := v.(*P).ins.GetByKey(t.Name())

--- a/test/pn_test.go
+++ b/test/pn_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/alxmsl/cpn"
+	"github.com/alxmsl/cpn/place"
 	"github.com/alxmsl/cpn/place/io"
 	"github.com/alxmsl/cpn/place/memory"
 	"github.com/alxmsl/cpn/transition"
@@ -50,6 +51,7 @@ func (s *PNSuite) TestPTP(c *C) {
 
 	i := 0
 	for m := range n.P("pout").Out() {
+		c.Assert(m.Value(), NotNil, Commentf("%#v", m))
 		c.Assert(m.Value().(int), Equals, i)
 		c.Assert(m.Path(), HasLen, 3)
 		c.Assert(m.Path()[0].N, Equals, "pin")
@@ -61,6 +63,11 @@ func (s *PNSuite) TestPTP(c *C) {
 		c.Assert(m.History()[1], Equals, m.Path()[0])
 		c.Assert(m.History()[2], Equals, m.Path()[1])
 		c.Assert(m.History()[3], Equals, m.Path()[2])
+
+		c.Assert(m.ValueByPlace("pin", 0), NotNil)
+		// Check that marks have been processed sequentially in the Petri Net
+		c.Assert(m.ValueByPlace("pin", 0).(int), Equals, i)
+		c.Assert(m.ValueByPlace("pout", 0), IsNil)
 
 		i += 1
 	}
@@ -107,6 +114,11 @@ func (s *PNSuite) TestPTTP(c *C) {
 		c.Assert(m.History()[2], Equals, m.Path()[1])
 		c.Assert(m.History()[3], Equals, m.Path()[2])
 
+		// We cannot check the mark's value in sequence, because marks could be processed in different sequences: using
+		// `t1` or `t2`. So, we check just that mark has value from place `pin` and doesn't have it from place `pout`
+		c.Assert(m.ValueByPlace("pin", 0), NotNil)
+		c.Assert(m.ValueByPlace("pout", 0), IsNil)
+
 		count += 1
 	}
 	c.Assert(count, Equals, 1000)
@@ -148,13 +160,21 @@ func (s *PNSuite) TestPTPP(c *C) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		for range n.P("pout1").Out() {
+		for m := range n.P("pout1").Out() {
+			c.Assert(m.ValueByPlace("pin", 0), NotNil)
+			c.Assert(m.ValueByPlace("pout1", 0), IsNil)
+			c.Assert(m.ValueByPlace("pout2", 0), IsNil)
+
 			atomic.AddInt64(&count, 1)
 		}
 	}()
 	go func() {
 		defer wg.Done()
-		for range n.P("pout2").Out() {
+		for m := range n.P("pout2").Out() {
+			c.Assert(m.ValueByPlace("pin", 0), NotNil)
+			c.Assert(m.ValueByPlace("pout1", 0), IsNil)
+			c.Assert(m.ValueByPlace("pout2", 0), IsNil)
+
 			atomic.AddInt64(&count, 1)
 		}
 	}()
@@ -195,9 +215,11 @@ func (s *PNSuite) TestPPTP(c *C) {
 
 	i := 0
 	for m := range n.P("pout").Out() {
+		c.Assert(m.Value(), NotNil)
 		c.Assert(m.Value().(int), Equals, i)
 		c.Assert(m.Path(), HasLen, 3)
-		c.Assert(m.Path()[0].N == "p1" || m.Path()[0].N == "p2", Equals, true)
+		// Path always has a place `p1`, because transition `t1` passes mark from the first place only
+		c.Assert(m.Path()[0].N, Equals, "p1")
 		c.Assert(m.Path()[1].N, Equals, "t1")
 		c.Assert(m.Path()[2].N, Equals, "pout")
 
@@ -206,6 +228,13 @@ func (s *PNSuite) TestPPTP(c *C) {
 		c.Assert(m.History()[1], Equals, m.Path()[0])
 		c.Assert(m.History()[2], Equals, m.Path()[1])
 		c.Assert(m.History()[3], Equals, m.Path()[2])
+
+		// Mark has value from place `p1` and doesn't have from place `p2` because transition `t1` passes mark from the
+		// first place only
+		c.Assert(m.ValueByPlace("p1", 0), NotNil)
+		c.Assert(m.ValueByPlace("p1", 0).(int), Equals, i)
+		c.Assert(m.ValueByPlace("p2", 0), IsNil)
+		c.Assert(m.ValueByPlace("pout", 0), IsNil)
 
 		i += 1
 	}
@@ -249,7 +278,9 @@ func (s *PNSuite) TestPPTTP(c *C) {
 	count := 0
 	for m := range n.P("pout").Out() {
 		c.Assert(m.Path(), HasLen, 3)
-		c.Assert(m.Path()[0].N == "p1" || m.Path()[0].N == "p2", Equals, true)
+		// Path always has a place `p1`, because both transitions `t1` and `t2` passes mark from the first place only.
+		c.Assert(m.Path()[0].N, Equals, "p1")
+		// Path can have both transitions here, because of concurrency execution.
 		c.Assert(m.Path()[1].N == "t1" || m.Path()[1].N == "t2", Equals, true)
 		c.Assert(m.Path()[2].N, Equals, "pout")
 
@@ -258,6 +289,13 @@ func (s *PNSuite) TestPPTTP(c *C) {
 		c.Assert(m.History()[1], Equals, m.Path()[0])
 		c.Assert(m.History()[2], Equals, m.Path()[1])
 		c.Assert(m.History()[3], Equals, m.Path()[2])
+
+		// Mark has value from place `p1` and doesn't have from place `p2` because both transitions `t1` and `t2` passes
+		// mark from the first place only. The same moment we can not predict the mark's value, because both transitions
+		// `t1` and `t2` work concurrently
+		c.Assert(m.ValueByPlace("p1", 0), NotNil)
+		c.Assert(m.ValueByPlace("p2", 0), IsNil)
+		c.Assert(m.ValueByPlace("pout", 0), IsNil)
 
 		count += 1
 	}
@@ -289,4 +327,57 @@ func (s *PNSuite) TestPrintNet(c *C) {
 	}()
 	n.RunSync()
 	c.Assert(w.String(), Equals, "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n")
+}
+
+func (s *PNSuite) TestMultipleValues(c *C) {
+	var n = cpn.NewPN()
+	n.P("p1",
+		cpn.WithContext(context.Background()),
+		cpn.WithPlace(memory.NewBlock()),
+	)
+	n.T("t1", cpn.WithFunction(transition.First))
+	n.P("p2",
+		cpn.WithContext(context.Background()),
+		cpn.WithPlace(place.NewPass(place.PassFuncOption(
+			func(ctx context.Context, m *cpn.M) {
+				m.SetValue("overwritten value from p2")
+				m.SetValue("value from p2")
+			},
+		))),
+	)
+	n.T("t2", cpn.WithFunction(transition.First))
+	n.P("p3",
+		cpn.WithContext(context.Background()),
+		cpn.WithPlace(place.NewPass(place.PassFuncOption(
+			func(ctx context.Context, m *cpn.M) {
+				m.SetValue("overwritten value from p3")
+				m.SetValue("value from p3")
+			},
+		))),
+	)
+	n.
+		PT("p1", "t1").
+		TP("t1", "p2").
+		PT("p2", "t2").
+		TP("t2", "p3")
+
+	var m = cpn.NewM("initial value")
+	go func() {
+		n.P("p1").In() <- m
+		n.P("p1").Close()
+	}()
+	n.RunSync()
+
+	// The backward compatibility check
+	c.Assert(m.Value(), NotNil)
+	c.Assert(m.Value().(string), Equals, "value from p3")
+
+	// Verify that the mark values from different places are available
+	c.Assert(m.ValueByPlace("not found", 0), IsNil)
+	c.Assert(m.ValueByPlace("p1", 0), NotNil)
+	c.Assert(m.ValueByPlace("p1", 0).(string), Equals, "initial value")
+	c.Assert(m.ValueByPlace("p2", 0), NotNil)
+	c.Assert(m.ValueByPlace("p2", 0).(string), Equals, "value from p2")
+	c.Assert(m.ValueByPlace("p3", 0), NotNil)
+	c.Assert(m.ValueByPlace("p3", 0).(string), Equals, "value from p3")
 }


### PR DESCRIPTION
At this moment a mark can store just one latest payload. This is not so good to use the net for tasks like data-flow
I added an ability to store pointer to data was stored in all places mark passed. 
To keep a backward-compatibility `M.Value()` returns latest payload. To set payload the method `M.SetValue(interface{})` is still available

To get payload was set in a specific place a new method is allowed to be used:
```go
func (m *M) ValueByPlace(name string, deep int) interface{}
```
where `name` is a place name; and `deep` could be used for cases mark passed the place several times in a loop